### PR TITLE
Update openapi.ts to fix the version

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -96,7 +96,7 @@ export interface OpenAPIBuilderOpts {
 }
 
 export default class OpenAPIBuilder {
-  public OPENAPI_VERSION: string = '3.0.0.';
+  public OPENAPI_VERSION: string = '3.0.0';
   public routes: Route[];
   public info: OpenAPIInfo;
   public servers: OpenAPIServer[];


### PR DESCRIPTION
The last dot in the version is giving error when shown in the swagger editor